### PR TITLE
Remove the resources directory page from public navigation and routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,6 @@ import Leaderboard from './components/Leaderboard/Leaderboard';
 import Supporter from './components/Supporter/Supporter';
 import Definitions from './components/Definitions/Definitions';
 import Shortcut from './components/Shortcut/Shortcut';
-import Resources from './components/Resources/Resources';
 import ScoringMethodology from './components/ScoringMethodology/ScoringMethodology';
 import Terms from './components/PrivacyTerms/Terms';
 import Privacy from './components/PrivacyTerms/Privacy';
@@ -52,7 +51,6 @@ const App = () => {
                 <Route path="/supporter" element={<Supporter />} />
                 <Route path="/definitions" element={<Definitions />} />
                 <Route path="/leaderboard" element={<Leaderboard />} />
-                <Route path="/resources" element={<Resources />} />
                 <Route 
                   path="/verifier" 
                   element={

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -127,9 +127,8 @@ const Navbar = () => {
 
   const resourcesDropdown = {
     title: "resources",
-    path: "/resources",
+    path: "/alt-text",
     items: [
-      { title: "library", path: "/resources" },
       { title: "alt text rating", path: "/alt-text" },
       // { title: "omnifeed", path: "/omnifeed" }, // Temporarily removed
       { title: "verifier", path: "/verifier" }

--- a/src/components/ScoringMethodology/ScoringMethodology.js
+++ b/src/components/ScoringMethodology/ScoringMethodology.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import './ScoringMethodology.css';
 import ScoreGauge from '../UserProfile/ScoreGauge';
-import { Link } from 'react-router-dom';
 import RelatedPagesNav from '../common/RelatedPagesNav';
 
 const ScoringMethodology = () => {
@@ -55,9 +54,6 @@ const ScoringMethodology = () => {
         </ol>
         <p>
           This is not an exhaustive list by any means, but it should get you started. The goal of the cred.blue score isn't to attempt to max it out... rather, the point is to foster healthy behavior and activity that benefits the entire community.
-        </p>
-        <p>
-          With that being said, check out the <Link to="/resources">resources page</Link> and toggle the "impacts score" filter to see some third-party apps that do have an influenece.
         </p>
 
         {/* Replace the old definitions link with the new RelatedPagesNav component */}

--- a/src/components/UserProfile/components/NarrativeCard.js
+++ b/src/components/UserProfile/components/NarrativeCard.js
@@ -19,7 +19,7 @@ const NarrativeCard = () => {
         {narrative2 && <p>{narrative2}</p>}
         {narrative3 && <p>{narrative3}</p>}
       </div>
-      <p className="learn-more-text">Learn more about the <Link to="/methodology" className="narrative-methodology-link">scoring methodology</Link> and <Link to="/definitions" className="narrative-methodology-link">key terms/definitions</Link> contained in this summary. Then check out the <Link to="/resources" className="narrative-methodology-link">resources page</Link> to take action!</p>
+      <p className="learn-more-text">Learn more about the <Link to="/methodology" className="narrative-methodology-link">scoring methodology</Link> and <Link to="/definitions" className="narrative-methodology-link">key terms/definitions</Link> contained in this summary.</p>
       <div className="disclaimer">
         <p><strong>NOTE: </strong>This summary was <strong>not</strong> generated using AI.</p>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pulls the resources/tools directory page out of the public app so it's no longer reachable through navigation or routing. The `Resources` component itself is left in place under `src/components/Resources/` along with the admin panel that manages it, so the data and UI can be brought back later if desired — it just isn't wired up anywhere user-facing now.

## Changes

- `src/App.jsx`: Remove the `Resources` import and the `/resources` route. The `/` -> `/home` redirect plus the `*` catch-all handle any stale `/resources` URLs by sending users back to home.
- `src/components/Navbar/Navbar.js`: Drop the "library" item from the resources dropdown and repoint the dropdown's trigger path from `/resources` to `/alt-text` so clicking the top-level "resources" label lands on a real page.
- `src/components/UserProfile/components/NarrativeCard.js`: Trim the trailing "Then check out the resources page to take action!" link from the narrative footer.
- `src/components/ScoringMethodology/ScoringMethodology.js`: Remove the "check out the resources page" paragraph and the now-unused `Link` import.

## Notes

- No mentions of `/resources` remain in user-facing nav, routes, or copy. The only remaining references are inside `Resources.js` itself (orphaned, not imported anywhere) and inside `Admin/AdminPanel.js`, which manages the Supabase-backed resource data.
- `plc.directory` references throughout the code are unrelated (they're the AT Protocol PLC directory) and were left untouched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b94cab2a-0ae7-498a-bc2b-acc2e9d5724a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b94cab2a-0ae7-498a-bc2b-acc2e9d5724a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

